### PR TITLE
Allow for selection of camera and focuser simulators from the chooser

### DIFF
--- a/ASCOM.Utilities.Core/GlobalCode.vb
+++ b/ASCOM.Utilities.Core/GlobalCode.vb
@@ -1325,8 +1325,7 @@ Friend Class PEReader
         ' Determine whether this is an assembly by testing whether we can load the file as an assembly, if so then it IS an assembly!
         TL.LogMessage("PEReader", "Determining whether this is an assembly")
         Try
-            ' Assembly.ReflectionOnlyLoadFrom not supported in .NET Core. Need to find another solution and/or evaluate if this is even needed.
-            ' SuppliedAssembly = Assembly.ReflectionOnlyLoadFrom(FileName)
+            Dim AssemName As AssemblyName = AssemblyName.GetAssemblyName(FileName)
             IsAssembly = True ' We got here without an exception so it must be an assembly
             TL.LogMessage("PEReader.IsAssembly", "Found an assembly because it loaded Ok to the reflection context: " & IsAssembly)
         Catch ex As System.IO.FileNotFoundException

--- a/ASCOM.Utilities.Core/GlobalCode.vb
+++ b/ASCOM.Utilities.Core/GlobalCode.vb
@@ -1301,7 +1301,7 @@ Friend Class PEReader
     Private stream As Stream
     Private IsAssembly As Boolean = False
     Private AssemblyInfo As AssemblyName
-    Private SuppliedAssembly As Assembly
+    ' Private SuppliedAssembly As Assembly
     Private AssemblyDeterminationType As String
     Private OS32BitCompatible As Boolean = False
     Private ExecutableBitness As Bitness
@@ -1325,7 +1325,8 @@ Friend Class PEReader
         ' Determine whether this is an assembly by testing whether we can load the file as an assembly, if so then it IS an assembly!
         TL.LogMessage("PEReader", "Determining whether this is an assembly")
         Try
-            SuppliedAssembly = Assembly.ReflectionOnlyLoadFrom(FileName)
+            ' Assembly.ReflectionOnlyLoadFrom not supported in .NET Core. Need to find another solution and/or evaluate if this is even needed.
+            ' SuppliedAssembly = Assembly.ReflectionOnlyLoadFrom(FileName)
             IsAssembly = True ' We got here without an exception so it must be an assembly
             TL.LogMessage("PEReader.IsAssembly", "Found an assembly because it loaded Ok to the reflection context: " & IsAssembly)
         Catch ex As System.IO.FileNotFoundException


### PR DESCRIPTION
Hi Daniel,

I found your work for ASCOM.Core and it is very helpful for a project of mine. I have been using your port as well as the telescope simulator and it has been working well.

I recently needed to start creating camera and focusers using the chooser and I was getting the following error:

![image](https://user-images.githubusercontent.com/174474/66695356-7634a080-ec75-11e9-86a9-559f614dc2bd.png)

In the Windows Event Viewer there was a message and a stack trace:

```
DriverCompatibilityMessage - Exception parsing ASCOM.Simulator.Camera, "file:///C:/Program Files (x86)/Common Files/ASCOM/Camera/ASCOM.Simulator.Camera/ASCOM.Simulator.Camera.DLL"
System.PlatformNotSupportedException: ReflectionOnly loading is not supported on this platform.
   at System.Reflection.Assembly.ReflectionOnlyLoadFrom(String assemblyFile)
   at ASCOM.Utilities.PEReader..ctor(String FileName, TraceLogger TLogger)
   at ASCOM.Utilities.VersionCode.DriverCompatibilityMessage(String ProgID, Bitness RequiredBitness, TraceLogger TL)
```

I used debug dlls and the pdb and stepped through until I found the offending function. It doesn't have any use whatsoever from what I can tell so I just commented it out for now (since this is all WIP and all 😄 ). 

This fix allowed me select camera and focuser simulators (and real devices) uses the chooser.

Note that `ReflectionOnlyLoad` also throws `PlatformNotSupported` exceptions and it has a dozen or so uses. I haven't digested what exactly it is being used for apart from detecting DLL compatibility, but it may be something that can be removed given that ASCOM.Core is .NET core.